### PR TITLE
gomod: update module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/calyptia/lua-sandbox-client
+module github.com/calyptia/go-lua-sandbox-client
 
 go 1.19
 


### PR DESCRIPTION
The name of the module should match the repository name.
This is causing:

```bash
$ go get github.com/calyptia/lua-sandbox-client
fatal: repository 'https://github.com/calyptia/lua-sandbox-client/' not found
```

```bash
$ go get github.com/calyptia/go-lua-sandbox-client
module declares its path as: github.com/calyptia/lua-sandbox-client
    but was required as: github.com/calyptia/go-lua-sandbox-client
```